### PR TITLE
[RFT] Use internal class in IServiceRegistration classes

### DIFF
--- a/ApiBoilerPlate/Infrastructure/Extensions/ServiceRegistrationExtension.cs
+++ b/ApiBoilerPlate/Infrastructure/Extensions/ServiceRegistrationExtension.cs
@@ -10,7 +10,7 @@ namespace ApiBoilerPlate.Infrastructure.Extensions
     {
         public static void AddServicesInAssembly(this IServiceCollection services, IConfiguration configuration)
         {
-            var appServices = typeof(Startup).Assembly.ExportedTypes
+            var appServices = typeof(Startup).Assembly.DefinedTypes
                             .Where(x => typeof(IServiceRegistration)
                             .IsAssignableFrom(x) && !x.IsInterface && !x.IsAbstract)
                             .Select(Activator.CreateInstance)

--- a/ApiBoilerPlate/Infrastructure/Installers/RegisterApiResources.cs
+++ b/ApiBoilerPlate/Infrastructure/Installers/RegisterApiResources.cs
@@ -16,7 +16,7 @@ using System.Net.Http.Headers;
 
 namespace ApiBoilerPlate.Infrastructure.Installers
 {
-    public class RegisterApiResources : IServiceRegistration
+    internal class RegisterApiResources : IServiceRegistration
     {
         public void RegisterAppServices(IServiceCollection services, IConfiguration config)
         {

--- a/ApiBoilerPlate/Infrastructure/Installers/RegisterContractMappings.cs
+++ b/ApiBoilerPlate/Infrastructure/Installers/RegisterContractMappings.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace ApiBoilerPlate.Infrastructure.Installers
 {
-    public class RegisterContractMappings : IServiceRegistration
+    internal class RegisterContractMappings : IServiceRegistration
     {
         public void RegisterAppServices(IServiceCollection services, IConfiguration configuration)
         {

--- a/ApiBoilerPlate/Infrastructure/Installers/RegisterModelValidators.cs
+++ b/ApiBoilerPlate/Infrastructure/Installers/RegisterModelValidators.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace ApiBoilerPlate.Infrastructure.Installers
 {
-    public class RegisterModelValidators: IServiceRegistration
+    internal class RegisterModelValidators: IServiceRegistration
     {
         public void RegisterAppServices(IServiceCollection services, IConfiguration configuration)
         {

--- a/ApiBoilerPlate/Infrastructure/Installers/RegisterRequestRateLimiter.cs
+++ b/ApiBoilerPlate/Infrastructure/Installers/RegisterRequestRateLimiter.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace ApiBoilerPlate.Infrastructure.Installers
 {
-    public class RegisterRequestRateLimiter : IServiceRegistration
+    internal class RegisterRequestRateLimiter : IServiceRegistration
     {
         public void RegisterAppServices(IServiceCollection services, IConfiguration configuration)
         {


### PR DESCRIPTION
Since the ``AddServicesInAssembly`` extension for the ``IServicesCollection`` interface only collects classes defined in the assembly. I think it would be better to define the ``IServiceRegistration`` classes to **internal** instead of **public**.

This change is purely aesthetic as calling the ``AddServicesInAssembly`` from another assembly _(by referencing the original boilerplate project)_ **does not pick up ``IServiceRegistration`` implementations outside the boilerplate project**

This merely signifies that these classes are implemented internally and are not meant to be exposed outside the original assembly.