### PR TITLE
[FET] Add readme in Db folder

### DIFF
--- a/ApiBoilerPlate/Infrastructure/HealthChecks/Db/README.md
+++ b/ApiBoilerPlate/Infrastructure/HealthChecks/Db/README.md
@@ -1,0 +1,1 @@
+Please don't remove this file as this is necessary for the HealthChecks sql lite db


### PR DESCRIPTION
Adding a README.md file in  Infrastructure/HealthChecks/Db/README.md 

A bug in healthchecks sql lite causes the app to not create a lite Db when the folder is not present. 