### PR TITLE
Missing using configuration

### DIFF
--- a/ApiBoilerPlate/appsettings.Logs.json
+++ b/ApiBoilerPlate/appsettings.Logs.json
@@ -1,5 +1,6 @@
 {
   "Serilog": {
+    "Using": [ "Serilog.Sinks.File", "Serilog.Filters.Expressions" ]
     "MinimumLevel": {
       "Default": "Information",
       "Override": {

--- a/ApiBoilerPlate/appsettings.Logs.json
+++ b/ApiBoilerPlate/appsettings.Logs.json
@@ -1,6 +1,6 @@
 {
   "Serilog": {
-    "Using": [ "Serilog.Sinks.File", "Serilog.Filters.Expressions" ]
+    "Using": [ "Serilog.Sinks.File", "Serilog.Filters.Expressions" ],
     "MinimumLevel": {
       "Default": "Information",
       "Override": {


### PR DESCRIPTION
Without the using configuration in settings, it would generate logs in both error and info. If there is an error or exception it would info log file and vice versa the info logs would also go to error log file. Adding the using configuration as illustrated in the code would filter the logs properly.